### PR TITLE
issue fix, more robust artwork reading, bumps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,11 +28,10 @@ jobs:
               run: |
                 for sample in ./samples/*.jpg; do
                   stdout=$(echo "$sample" | ./target/debug/foobar2000-catbox)
-                  echo "$output "
                   if [[ $stdout =~ ^https:\/\/files.catbox.moe\/[A-Za-z0-9]*\.jpg$ ]]; then
-                    echo "🎉 Yes"
+                    echo "$stdout 🎉 Yes"
                   else
-                    echo "😥 No"
+                    echo "$stdout 😥 No"
                     exit 1
                   fi
                 done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,19 @@
+name: Rust
+
+on:
+    push:
+        branches: ["development"]
+
+env:
+    CARGO_TERM_COLOR: always
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout from repository
+              uses: actions/checkout@v4
+            - name: Compile the application
+              run: cargo build
+            - name: Run with samples
+              run: echo "./samples/1205.jpg" | ./target/debug/foobar2000-catbox

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,8 +18,10 @@ jobs:
               with:
                 path: |
                   ~/.cargo/bin/
-                  ~/.cargo/registry/
-                  ~/.cargo/git/
+                  ~/.cargo/registry/index/
+                  ~/.cargo/registry/cache/
+                  ~/.cargo/git/db/
+                  target/
                 key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
                 restore-keys: ${{ runner.os }}-cargo-
             - name: 🛠️ Compile the application

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,5 +18,5 @@ jobs:
             - name: Run multiple samples
               run: |
                 for sample in ./samples/*.jpg; do
-                  echo "$sample" | ./target/release/foobar2000-catbox
+                  echo "$sample" | ./target/debug/foobar2000-catbox
                 done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,5 +15,8 @@ jobs:
               uses: actions/checkout@v4
             - name: Compile the application
               run: cargo build
-            - name: Run with samples
-              run: echo "./samples/1205.jpg" | ./target/debug/foobar2000-catbox
+            - name: Run multiple samples
+              run: |
+                for sample in ./samples/*.jpg; do
+                  echo "$sample" | ./target/release/foobar2000-catbox
+                done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,13 @@ jobs:
         steps:
             - name: Checkout from repository
               uses: actions/checkout@v4
+            - name: Cargo cache
+              uses: actions/cache@v3
+              with:
+                path: ~/.cargo/git
+                key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+                restore-keys: |
+                  ${{ runner.os }}-cargo-index-
             - name: Compile the application
               run: cargo build
             - name: Run multiple samples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,5 +33,6 @@ jobs:
                   else
                     echo "$stdout 😥 No"
                     exit 1
+                  echo "✨ All samples were successfully uploaded"
                   fi
                 done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,10 +16,12 @@ jobs:
             - name: Cargo cache
               uses: actions/cache@v3
               with:
-                path: ~/.cargo/git
-                key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-                restore-keys: |
-                  ${{ runner.os }}-cargo-index-
+                path: |
+                  ~/.cargo/bin/
+                  ~/.cargo/registry/
+                  ~/.cargo/git/
+                key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+                restore-keys: ${{ runner.os }}-cargo-
             - name: Compile the application
               run: cargo build
             - name: Run multiple samples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,9 +11,9 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout from repository
+            - name: 📋 Checkout from repository
               uses: actions/checkout@v4
-            - name: Cargo cache
+            - name: 🗄️ Cargo cache
               uses: actions/cache@v3
               with:
                 path: |
@@ -22,10 +22,17 @@ jobs:
                   ~/.cargo/git/
                 key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
                 restore-keys: ${{ runner.os }}-cargo-
-            - name: Compile the application
+            - name: 🛠️ Compile the application
               run: cargo build
-            - name: Run multiple samples
+            - name: 🧪 Run multiple samples
               run: |
                 for sample in ./samples/*.jpg; do
-                  echo "$sample" | ./target/debug/foobar2000-catbox
+                  stdout=$(echo "$sample" | ./target/debug/foobar2000-catbox)
+                  echo "$output "
+                  if [[ $stdout =~ ^https:\/\/files.catbox.moe\/[A-Za-z0-9]*\.jpg$ ]]; then
+                    echo "🎉 Yes"
+                  else
+                    echo "😥 No"
+                    exit 1
+                  fi
                 done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "audiotags"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e797ce0164cf599c71f2c3849b56301d96a3dc033544588e875686b050ed39"
+dependencies = [
+ "audiotags-macro",
+ "id3",
+ "metaflac",
+ "mp4ameta",
+ "readme-rustdocifier",
+ "thiserror",
+]
+
+[[package]]
+name = "audiotags-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaa9b2312fc01f7291f3b7b0f52ed08b1c0177c96a2e696ab55695cc4d06889"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +103,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitstream-io"
@@ -281,6 +307,7 @@ dependencies = [
 name = "foobar2000-catbox"
 version = "1.0.4"
 dependencies = [
+ "audiotags",
  "curl",
  "image",
 ]
@@ -329,13 +356,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "image"
-version = "0.25.1"
+name = "hex"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "id3"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f4e785f2c700217ee82a1c727c720449421742abd5fcb2f1df04e1244760e9"
+dependencies = [
+ "bitflags 2.6.0",
+ "byteorder",
+ "flate2",
+]
+
+[[package]]
+name = "image"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
 dependencies = [
  "bytemuck",
- "byteorder",
+ "byteorder-lite",
  "color_quant",
  "exr",
  "gif",
@@ -411,6 +455,12 @@ name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lebe"
@@ -489,6 +539,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "metaflac"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f083edae4a21f5acb1fda8220d1c14fa31f725bfd4e21005a14c2d8944db9b"
+dependencies = [
+ "byteorder",
+ "hex",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +563,22 @@ dependencies = [
  "adler",
  "simd-adler32",
 ]
+
+[[package]]
+name = "mp4ameta"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb23d62e8eb5299a3f79657c70ea9269eac8f6239a76952689bcd06a74057e81"
+dependencies = [
+ "lazy_static",
+ "mp4ameta_proc",
+]
+
+[[package]]
+name = "mp4ameta_proc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07dcca13d1740c0a665f77104803360da0bdb3323ecce2e93fa2c959a6d52806"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -618,7 +694,7 @@ version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -782,6 +858,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "readme-rustdocifier"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
 
 [[package]]
 name = "rgb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,7 @@ codegen-units = 1
 version = "0.4.46"
 
 [dependencies.image]
-version="0.25.1"
+version="0.25.2"
+
+[dependencies.audiotags]
+version="0.5.0"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
-# foobar2000-catbox
+## 📰 Quick description
 
-## 📰 Short description
+A helper application to be used with [foo_discord_rich](https://github.com/TheQwertiest/foo_discord_rich) for uploading album artwork to [catbox.moe](https://catbox.moe/).
 
-This application takes an image path as input, downscales and compressed the image in memory, then uploads it to [catbox.moe](https://catbox.moe/) using their API, and finally prints the resulting link to the uploaded image. It's not meant to be started manually, but rather be invoked by this fork of [foo_discord_rich](https://github.com/s0hv/foo_discord_rich) by [s0hv](https://github.com/s0hv) to upload cover art for music.
+## 🚨 Attention
 
-## 🔗 Links
+Previous development was targeted towards a [fork of foo_discord_rich](https://github.com/s0hv/foo_discord_rich). No longer will this be the case, as future development will instead target the [original repository](https://github.com/TheQwertiest/foo_discord_rich) only.
 
-- [Configuration file](#-configuration-file-optional)
-- [Application flow](#-application-flow-outdated)
-- [TODO](#-todo)
-
-## 📝 Configuration file [Optional]
+## 📝 Configuration file [optional]
 
 We're using a very primitive algorithm to parse key value pairs from a `config.txt` file to allow fine tuning of the output without having to recompile the application. It reads this file line by line, separating key value pairs using `=` as the delimiter. You don't need to include it at all, nor do you need to define every value. When a key isn't defined or is defined improperly, it will always fallback to the default value. Consider this when modifying these values, to be sure they are not malformed.
 
@@ -25,21 +21,23 @@ Here's a table showing all of the possible keys and their default values.
 
 Place or create a file named `config.txt` next to the `foobar2000-catbox.exe` executable. See the example [config.txt](config.txt) in this repository.
 
-## 📊 Application flow (🚧Outdated🚧)
+## 📊 Application flow
 
-Here's a small flowchart, for visualizing the flow of the application.
+Here's a small flowchart; A non-precise visualization outlining the flow of the application.
 
 ```mermaid
 flowchart TD
-    A(Application Starts)-->
-    B(Get text from\nstandard input)-->
-    C(File exists?)-.->|No|D(Failure)
-    C-->|Yes|E(Read using image::io)
-    E-->F(Resize to 500px by 500px)
-    F-->G(Write JPG\ninto memory buffer)
-    G-->H(Construct and\nsend POST)
-    H-.->|Not Ok|I(Failure)
-    H-->|Ok|J(Print resulting URL\nto standard output)
+    A(Set up configuration variables)-.->
+    B(Await text from standard input)-.->
+    C(Get file contents into buffer)-.->
+    D(Load buffer into an image object)-.->
+    E(Width or height larger than maximum?)-.->
+    |Yes|F(Resize image object)-.->
+    G(JPEG encode final image object)
+    E-.->|No|G-.->
+    H(Construct multipart form and request with final image)-.->
+    I(Perform POST request)-.->
+    J(Write resulting URL to standard output)
 ```
 
 ## 📋 TODO
@@ -47,4 +45,4 @@ flowchart TD
 - [x] make a really cool flowchart
 - [x] automatic compression/downscaling
 - [x] basic configuration file for quality preferences
-- [ ] installation instructions
+- [x] installation instructions (linked to setup instructions)

--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ flowchart TD
 - [x] automatic compression/downscaling
 - [x] basic configuration file for quality preferences
 - [x] installation instructions (linked to setup instructions)
+- [ ] add small audio samples with embedded artwork

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Previous development was targeted towards a [fork of foo_discord_rich](https://g
 
 ## 📝 Configuration file [optional]
 
-We're using a very primitive algorithm to parse key value pairs from a `config.txt` file to allow fine tuning of the output without having to recompile the application. It reads this file line by line, separating key value pairs using `=` as the delimiter. You don't need to include it at all, nor do you need to define every value. When a key isn't defined or is defined improperly, it will always fallback to the default value. Consider this when modifying these values, to be sure they are not malformed.
+You may include a configuration file for tuning behavior. You don't need to include it at all for basic functionality, nor do you need to define every value. When a key isn't defined or is improper, it will always fallback to the default value.
 
-Here's a table showing all of the possible keys and their default values.
+Again, remember that this is optional. To use, create a file named `config.txt` next to the executable. Check out the example [config.txt](config.txt) in this repository as a base to start with.
+
+See the table below showing all of the possible keys and their default values.
 | Name | Default value | Description |
 | - | - | - |
 | MAX_WIDTH | 500 | A number, the width of the image will always be clamped to at most this width in pixels.|
@@ -18,8 +20,6 @@ Here's a table showing all of the possible keys and their default values.
 | QUALITY | 80 | A number, the percentage of quality to retain. Higher looks better but has a larger file size and is slower, whereas lower looks worse but has a smaller file size and is faster. |
 | USER_AGENT | Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0 | A string, see [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) for a description of this header. We need to send this with the POST request or else the default endpoint [catbox.moe](https://catbox.moe/) will kill the connection. This is out of our control, see issue #4. |
 | ENDPOINT | <https://catbox.moe/user/api.php> | A string, the destination of our POST request. Since the form is designed to work with the format specified by the [tool API section on catbox](https://catbox.moe/tools.php), it's unlikely you'll be able to change this. |
-
-Place or create a file named `config.txt` next to the `foobar2000-catbox.exe` executable. See the example [config.txt](config.txt) in this repository.
 
 ## 📊 Application flow
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the table below showing all of the possible keys and their default values.
 | MAX_WIDTH | 500 | A number, the width of the image will always be clamped to at most this width in pixels.|
 | MAX_HEIGHT | 500 | A number, the height of the image will always be clamped to at most this height in pixels. |
 | QUALITY | 80 | A number, the percentage of quality to retain. Higher looks better but has a larger file size and is slower, whereas lower looks worse but has a smaller file size and is faster. |
-| USER_AGENT | Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0 | A string, see [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) for a description of this header. We need to send this with the POST request or else the default endpoint [catbox.moe](https://catbox.moe/) will kill the connection. This is out of our control, see issue #4. |
+| USER_AGENT | Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0 | A string, see [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) for a description of this header. We need to send this with the POST request or else the default endpoint [catbox.moe](https://catbox.moe/) will kill the connection. This is out of our control, see issue #4. |
 | ENDPOINT | <https://catbox.moe/user/api.php> | A string, the destination of our POST request. Since the form is designed to work with the format specified by the [tool API section on catbox](https://catbox.moe/tools.php), it's unlikely you'll be able to change this. |
 
 ## 📊 Application flow

--- a/config.txt
+++ b/config.txt
@@ -1,5 +1,5 @@
 MAX_WIDTH=500
 MAX_HEIGHT=500
 QUALITY=80
-USER_AGENT=Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0
+USER_AGENT=Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0
 ENDPOINT=https://catbox.moe/user/api.php

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ use image::codecs::jpeg::JpegEncoder;
 struct ResponseBody(Vec<u8>);
 
 impl Handler for ResponseBody {
-    // I stole this. Sorry
     fn write(&mut self, data: &[u8]) -> Result<usize, WriteError> {
         self.0.extend_from_slice(data);
         Ok(data.len())
@@ -27,11 +26,10 @@ mod error {
     pub const IMAGE_LOADING_ERROR: i32 = 3;
     pub const IMAGE_ENCODING_ERROR: i32 = 4;
     pub const HTTP_REQUEST_ERROR: i32 = 5;
+    pub const HTTP_RESPONSE_ERROR: i32 = 6;
 }
 
 fn main() {
-    // const THRESHOLD: usize = 2097152; // 2MiB
-
     // Configuration map initialization
 
     let config_path: &Path = &env::current_exe()
@@ -154,7 +152,14 @@ fn main() {
 
     match easy.perform() {
         Ok(_) => {
-            println!("{}", String::from_utf8_lossy(easy.get_ref().0.as_slice()));
+            let response_code: u32 = easy.response_code().unwrap();
+
+            if response_code == 200 || response_code == 304 {
+                println!("{}", String::from_utf8_lossy(easy.get_ref().0.as_slice()));
+            } else {
+                eprintln!("Response error {}", response_code);
+                exit(error::HTTP_RESPONSE_ERROR);
+            }
         }
         Err(e) => {
             eprintln!("{}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
     const DEFAULT_MAX_HEIGHT: u32 = 500;
     const DEFAULT_QUALITY: u8 = 80;
     let default_user_agent: String =
-        "Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0".to_string();
+        "Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0".to_string();
     let default_endpoint: String = "https://catbox.moe/user/api.php".to_string();
 
     // Configuration value initialization

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::{
     process::exit,
 };
 
+use audiotags::{AudioTag, Tag};
 use curl::easy::{Easy2, Form, Handler, List, WriteError};
 use image::codecs::jpeg::JpegEncoder;
 
@@ -22,7 +23,7 @@ impl Handler for ResponseBody {
 
 mod error {
     pub const FILE_NOT_FOUND: i32 = 1;
-    pub const FILE_SYSTEM_READ_ERROR: i32 = 2;
+    // pub const FILE_SYSTEM_READ_ERROR: i32 = 2;
     pub const IMAGE_LOADING_ERROR: i32 = 3;
     pub const IMAGE_ENCODING_ERROR: i32 = 4;
     pub const HTTP_REQUEST_ERROR: i32 = 5;
@@ -102,10 +103,12 @@ fn main() {
 
     let file_name: &str = file_path.file_name().unwrap().to_str().unwrap();
 
-    let file_buffer: Vec<u8> = std::fs::read(&file_path).unwrap_or_else(|_| {
-        eprintln!("Failed to read from filesystem");
-        exit(error::FILE_SYSTEM_READ_ERROR);
-    });
+    let file_buffer: Vec<u8> = Tag::new()
+        .read_from_path(file_path)
+        .and_then(|file_tag: Box<dyn AudioTag + Send + Sync>| {
+            Ok(file_tag.album_cover().unwrap().data.to_vec())
+        })
+        .unwrap_or_else(|_| std::fs::read(&file_path).unwrap());
 
     let image_buffer: image::DynamicImage =
         image::load_from_memory(&file_buffer).unwrap_or_else(|_| {


### PR DESCRIPTION
- add testing workflow
- introduce audiotags crate to try a open and read of album artwork directly from audio files (leftover support for [v2.0.0](https://github.com/TheQwertiest/foo_discord_rich/releases/tag/v2.0.0))
- fix #10 by adding check and handle of HTTP response code, on a successful request
- reduce/simplify information in readme
- crate and user-agent version bumps